### PR TITLE
XSpec support Phase 2: refinements, extensions and testing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: XSpec Test Results
           comment_mode: always
-          files: "**/*junit.xml"
+          files: "testing/**/*junit.xml"
           report_individual_runs: true
           deduplicate_classes_by_file_name: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: XSpec Test Results
           comment_mode: always
-          files: "testing/xspec-reports/**/*_junit.xml"
+          files: "**/*_junit.xml"
           report_individual_runs: true
           deduplicate_classes_by_file_name: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: XSpec Test Results
           comment_mode: always
-          files: "testing/**/*junit.xml"
+          files: "**/*junit.xml"
           report_individual_runs: true
           deduplicate_classes_by_file_name: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
+      - name: Look at files
+        run: |
+          find '.' -iname *.xml
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: XSpec Test Results
           comment_mode: always
-          files: "**/*_junit.xml"
+          files: "**/*junit.xml"
           report_individual_runs: true
           deduplicate_classes_by_file_name: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
-          path: **/*_junit.xml # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
+          path: **/*_junit.xml
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
-          path: "**/*_junit.xml"
+          path: "**/*junit.xml"
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,7 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
-          # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
-          path: |
-            **/*_junit.xml
+          path: **/*_junit.xml # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         id: setup
       - name: Run smoketests
         run: |
+          ls -lha
           ./xp3.sh smoketest/POWER-UP.xpl
           ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           name: Test Results
           # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
           path: |
-            testing/xspec-reports/**/*_junit.xml
+            **/*_junit.xml
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
-          name: Test Results
+          name: XSpec Test Results
           path: |
             **/*junit.xml
             !lib/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
-          path: **/*_junit.xml
+          path: "**/*_junit.xml"
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,9 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
-          path: "**/*junit.xml"
+          path: |
+            **/*junit.xml
+            !lib/**
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         id: setup
       - name: Run smoketests
         run: |
-          ls -lha
+          ls -lha lib
           ./xp3.sh smoketest/POWER-UP.xpl
           ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl

--- a/smoketest/SMOKETEST-XSPEC.xpl
+++ b/smoketest/SMOKETEST-XSPEC.xpl
@@ -11,7 +11,7 @@
    
    <p:identity message="[SMOKETEST-XSPEC] Testing XSpec by running ./congratulations-xslt.xspec"/>
    
-   <ox:xspec-execute name="execute-xspec"/>
+   <ox:xslt-xspec-execute name="execute-xspec"/>
    
    <p:identity message="[SMOKETEST-XSPEC] All done, successful run"/>
 

--- a/smoketest/doing-well-schematron.xspec
+++ b/smoketest/doing-well-schematron.xspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="doing-well.sch">
+   
+   <x:scenario label="Doing well, thank you - checks out">
+      <x:context>
+         <CONGRATULATIONS>
+            <doing-well>THANK YOU</doing-well>
+         </CONGRATULATIONS>
+      </x:context>
+      
+      <x:expect-not-assert id="doing-well_positive-assertion" label="Okay input looks good"/>
+      <x:expect-assert     id="doing-well_negative-assertion" label="Liars still lying"/>
+      <x:expect-report     id="doing-well_positive-report"    label="Everyone is welcome"/>
+      <x:expect-not-report id="doing-well_negative-report"    label="Quiet is quiet"/>
+   </x:scenario>
+   
+   <x:scenario label="Doing well but not so thankful -">
+      <x:context>
+         <CONGRATULATIONS>
+            <doing-well>But not providing the expected answer</doing-well>
+         </CONGRATULATIONS>
+      </x:context>
+      
+      <x:expect-assert     id="doing-well_positive-assertion" label="Answer isn't good"/>
+      <x:expect-assert     id="doing-well_negative-assertion" label="Liars still lying"/>
+      <x:expect-not-report id="doing-well_positive-report"    label="Everyone is welcome - not"/>
+      <x:expect-not-report id="doing-well_negative-report"    label="Quiet is quiet"/>
+   </x:scenario>
+   
+</x:description>

--- a/smoketest/doing-well.sch
+++ b/smoketest/doing-well.sch
@@ -6,14 +6,21 @@
       
       But it can easily be adjusted to show validation behaviors with @assert-valid='true|false' in the XProc
  -->
-   
-   <!-- Turning the report/@test to 'true()' issues an innocuous message but renders a document invalid -->
-   <!-- Turning the assert/@test to 'false()' will test the Schematron assertion capability - everything is invalid now too. -->
+
    
    <sch:pattern>
       <sch:rule context="/*">
+         <!-- Turning the report/@test to 'true()' issues an innocuous message but renders a document invalid -->
+         <!-- Turning the assert/@test to 'false()' will test the Schematron assertion capability - everything is invalid now too. -->
          <sch:report test="false()">CONGRATULATIONS - you have performed Schematron validation on a <sch:name/> document.</sch:report>
          <sch:assert test="true()">An assertion should fail when it is false.</sch:assert>
+      </sch:rule>
+      <sch:rule context="doing-well">
+         <sch:let name="thanks" value="normalize-space(.) = 'THANK YOU'"/>
+         <sch:assert id="doing-well_positive-assertion" test="$thanks">When doing well, say THANK YOU</sch:assert>
+         <sch:assert id="doing-well_negative-assertion" test="not(.)">Never! (A Cretan never tells the truth.)</sch:assert>
+         <sch:report id="doing-well_positive-report"    test="$thanks">You are welcome</sch:report>
+         <sch:report id="doing-well_negative-report"    test="not(.)">This will never report.</sch:report>
       </sch:rule>
    </sch:pattern>
    

--- a/testing/BATCH-XSPEC-JUNIT.xpl
+++ b/testing/BATCH-XSPEC-JUNIT.xpl
@@ -25,7 +25,7 @@
       <p:variable name="html-report-path"  select="replace($relative-path,'\.xspec$','') || '_report.html' "/>
       <p:variable name="junit-report-path" select="replace($relative-path,'\.xspec$','') || '_junit.xml' "/>
       
-      <ox:xspec-execute name="execute-xspec"/>
+      <ox:xslt-xspec-execute name="execute-xspec"/>
       
       <!--<p:store message="[BATCH-XSPEC-JUNIT] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">
          <p:with-input port="source" pipe="xspec-html-report@execute-xspec"/>

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -26,7 +26,7 @@
       <p:variable name="html-report-path"  select="replace($relative-path,'\.xspec$','') || '_report.html' "/>
       <p:variable name="junit-report-path" select="replace($relative-path,'\.xspec$','') || '_junit.xml' "/>
       
-      <ox:xspec-execute name="execute-xspec"/>
+      <ox:xslt-xspec-execute name="execute-xspec"/>
       
       <p:store message="[BATCH-XSPEC] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">
          <p:with-input port="source" pipe="xspec-html-report@execute-xspec"/>

--- a/testing/TEST-XSPEC-SET.xpl
+++ b/testing/TEST-XSPEC-SET.xpl
@@ -7,6 +7,12 @@
    >
 
    <!-- Pipeline to be called as subpipeline, delivering a list of XProcs -->
+
+   <!--Keep in mind that as construed tby tools, validation presumes *without further qualification*
+       that any report or assertion returned by a Schematron makes the containing document 'invalid'.
+   
+       Schematrons used for query and diagnostics that do not follow this rule shouldn't be listed
+       and run under CI/CD -->
    
    <p:input port="source" sequence="true">
       <!-- We need content type because xspec suffix throws off the parser -->

--- a/xspec/xspec-execute.xpl
+++ b/xspec/xspec-execute.xpl
@@ -1,64 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+<p:library  xmlns:p="http://www.w3.org/ns/xproc"
    xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
    xmlns:x="http://www.jenitennison.com/xslt/xspec"
-   name="xspec-execute"
-   type="ox:xspec-execute" xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3">
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3">
 
-<!-- XProc 3.0 rendition of saxon-xslt-harness
+
+   <!-- XProc 3.0 rendition of saxon-xslt-harness
      -->
-<!-- Credit: Florent Georges is the author of the original XProc 1.0 XSpec testing harnesses, which this code (in its first iteration) sets out to emulate -->
+   <!-- Credit: Florent Georges is the author of the original XProc 1.0 XSpec testing harnesses, which this code (in its first iteration) sets out to emulate -->
+   
+   <!-- Providing a relative path to XSpec (top-level directory) on this system. with trailing slash -->   
+   <p:option name="xspec-home" select="'../lib/xspec-3.0.3/'" static="true"/>
+   
+   <p:declare-step name="xslt-xspec-execute" type="ox:xslt-xspec-execute">      
+      <p:input port="xspec-source" primary="true" content-types="application/xml"/>
+      
+      <p:output port="xspec-html-report" primary="true" pipe="result@html-report"/>
+      <p:output port="xspec-junit-report" primary="false" pipe="result@junit-report"/>
+      
+      <p:variable name="compiler-xslt"  select="$xspec-home || 'src/compiler/compile-xslt-tests.xsl'"/>
+      <p:variable name="formatter-xslt" select="$xspec-home || 'src/reporter/format-xspec-report.xsl'"/>
+      <p:variable name="junit-xslt"     select="$xspec-home || 'src/reporter/junit-report.xsl'"/>
 
-   <p:input port="xspec-source" primary="true" content-types="application/xml">
-      <p:document href="../smoketest/congratulations-xslt.xspec" content-type="application/xml"/>
-   </p:input>
-   
-   <p:output port="xspec-html-report" primary="true" pipe="result@html-report"/>
-   
-   <p:output port="xspec-junit-report" primary="false" pipe="result@junit-report"/>
+      <p:xslt name="compile-xspec">
+         <p:with-input port="stylesheet" href="{ $compiler-xslt }"/>
+      </p:xslt>
 
-   <!-- Provide a relative path to XSpec (top-level directory) on this system -->
-   <p:variable name="xspec-home"     select="'../lib/xspec-3.0.3/'"/>
-   
-   <p:variable name="compiler-xslt"  select="$xspec-home || 'src/compiler/compile-xslt-tests.xsl'"/>
-   <p:variable name="formatter-xslt" select="$xspec-home || 'src/reporter/format-xspec-report.xsl'"/>
-   <p:variable name="junit-xslt"     select="$xspec-home || 'src/reporter/junit-report.xsl'"/>
-   
-   <p:xslt name="compile-xspec">
-     <p:with-input port="stylesheet" href="{ $compiler-xslt }"/>
-   </p:xslt>
-   
-   <!-- A small adjustment to the compiled XSLT wakes up the 'secondary' port where we can see it ...  -->
-   <p:add-attribute name="adjusted-runtime"
-      match="/*/xsl:template[@name='Q{{http://www.jenitennison.com/xslt/xspec}}main']/xsl:result-document"
-      attribute-name="href" attribute-value="report"
-      xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />
-   
-   <!-- run the XSLT -->
-   <p:xslt name="execute-xspec">
-      <p:with-input port="source"><p:empty/></p:with-input>
-      <p:with-input port="stylesheet" pipe="result@adjusted-runtime"/>
-      <p:with-option name="template-name" select="'Q{http://www.jenitennison.com/xslt/xspec}main'"/>
-   </p:xslt>
-   
-   <p:identity name="xspec-report">
-      <p:with-input port="source" pipe="secondary@execute-xspec"/>
-   </p:identity>
-   
-   <!-- A report looks like: <x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/> -->
-   
-   <p:xslt name="html-report">
-      <p:with-input port="stylesheet" href="{ $formatter-xslt }"/>
-      <p:with-option name="parameters" select="map { 'inline-css': 'true' }"/>
-   </p:xslt>
-   
-   <p:string-replace match="text()" replace="translate(., '', '&lt;&gt;')"/>
-   
-   <p:sink/>
-   
-   <p:xslt name="junit-report">
-      <p:with-input port="source" pipe="result@xspec-report"/>
-      <p:with-input port="stylesheet" href="{ $junit-xslt }"/>
-   </p:xslt>
-   
-</p:declare-step>
+      <!-- A small adjustment to the compiled XSLT wakes up the 'secondary' port where we can see it ...  -->
+      <p:add-attribute name="adjusted-runtime"
+         match="/*/xsl:template[@name='Q{{http://www.jenitennison.com/xslt/xspec}}main']/xsl:result-document"
+         attribute-name="href" attribute-value="report" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>
+
+      <!-- run the XSLT -->
+      <p:xslt name="execute-xspec">
+         <p:with-input port="source">
+            <p:empty/>
+         </p:with-input>
+         <p:with-input port="stylesheet" pipe="result@adjusted-runtime"/>
+         <p:with-option name="template-name" select="'Q{http://www.jenitennison.com/xslt/xspec}main'"/>
+      </p:xslt>
+
+      <p:identity name="xspec-report">
+         <p:with-input port="source" pipe="secondary@execute-xspec"/>
+      </p:identity>
+
+      <!-- A report looks like: <x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/> -->
+
+      <p:xslt name="html-report">
+         <p:with-input port="stylesheet" href="{ $formatter-xslt }"/>
+         <p:with-option name="parameters" select="map { 'inline-css': 'true' }"/>
+      </p:xslt>
+
+      <p:string-replace match="text()" replace="translate(., '', '&lt;&gt;')"/>
+
+      <p:sink/>
+
+      <p:xslt name="junit-report">
+         <p:with-input port="source" pipe="result@xspec-report"/>
+         <p:with-input port="stylesheet" href="{ $junit-xslt }"/>
+      </p:xslt>
+
+   </p:declare-step>
+</p:library>


### PR DESCRIPTION
# Committer Notes

This PR should complete work initiated with #5, at least relative to the goal of 'stable and well documented' XSpec support of XSLT.

NB - Schematron and XQuery are for the moment Nice To Have, not blocking requirements.

### All Submissions:

- [ ] Follow [Contributing](https://github.com/usnistgov/oscal-xproc3/blob/main/CONTRIBUTING.md) guidelines
- [ ] Make no changes duplicating or conflicting with other open [Pull Requests](https://github.com/usnistgov/oscal-xproc3/pulls)
- [ ] Have been squashed to keep only relevant interim commits, if any \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have been tested manually
- [ ] Pass all CI/CD checks

### Changes to Core Features:

- [ ] The Issue history, discussions and new documentation provide context for new features -- everything is reasonably self-explanatory
- [ ] New tests are included
- [ ] New examples are included
- [ ] Everything in readme and TESTING documents has been updated
