### PR TITLE
Fix broken link in readme

### DIFF
--- a/lib/readme.md
+++ b/lib/readme.md
@@ -22,7 +22,7 @@ When run by any conformant XProc engine the pipelines should perform similarly a
 - [morgana-config.xml](morgana-config.xml) - Morgana configuration file
 - [GRAB-SAXON.xpl](GRAB-SAXON.xpl) - Saxon download and installation pipeline
 - [GRAB-SCHXSLT.xpl](GRAB-SCHXSLT.xpl) - SchXSLT download pipeline
-- [GRAB-XSPEC.xpl](GRAB-XSPECT.xpl) - XSpec download pipeline
+- [GRAB-XSPEC.xpl](GRAB-XSPEC.xpl) - XSpec download pipeline
 
 ## Restore
 


### PR DESCRIPTION
# Committer Notes

The link to the XSpec pipeline didn't work because the file name had a stray character. This PR removes the stray character.

While I could have requested that this change be included in #13, it was simple to just do it.

### All Submissions:

- [ ] Follow [Contributing](https://github.com/usnistgov/oscal-xproc3/blob/main/CONTRIBUTING.md) guidelines
- [x] Make no changes duplicating or conflicting with other open [Pull Requests](https://github.com/usnistgov/oscal-xproc3/pulls)
- [x] Have been tested manually
- [x] Pass all CI/CD checks

### Changes to Core Features:

- [ ] The Issue history, discussions and new documentation provide context for new features -- everything is reasonably self-explanatory
- [ ] New tests are included
- [ ] New examples are included
- [ ] Everything in readme and TESTING documents has been updated
